### PR TITLE
Message identification prefix

### DIFF
--- a/lib/sepa_king/account.rb
+++ b/lib/sepa_king/account.rb
@@ -4,10 +4,13 @@ module SEPA
     include ActiveModel::Validations
     extend Converter
 
-    attr_accessor :name, :iban, :bic
+    attr_accessor :name, :iban, :bic, :message_identification_prefix
     convert :name, to: :text
 
     validates_length_of :name, within: 1..70
+    validates :message_identification_prefix,
+              format: { with: /[a-zA-Z]/ },
+              if: -> { message_identification_prefix.present? }
     validates_with BICValidator, IBANValidator, message: "%{value} is invalid"
 
     def initialize(attributes = {})

--- a/lib/sepa_king/account.rb
+++ b/lib/sepa_king/account.rb
@@ -9,7 +9,7 @@ module SEPA
 
     validates_length_of :name, within: 1..70
     validates :message_identification_prefix,
-              format: { with: /[a-zA-Z]/ },
+              format: { with: /\A[-a-zA-Z0-9_]+\z/ },
               if: -> { message_identification_prefix.present? }
     validates_with BICValidator, IBANValidator, message: "%{value} is invalid"
 

--- a/lib/sepa_king/message.rb
+++ b/lib/sepa_king/message.rb
@@ -77,8 +77,10 @@ module SEPA
     end
 
     # Get unique identifer for the message (with fallback to a random string)
+    # Set prefix to account.message_identification_prefix it is present
     def message_identification
-      @message_identification ||= "SEPA-KING/#{SecureRandom.hex(11)}"
+      prefix = account.message_identification_prefix || 'SEPA-KING'
+      @message_identification ||= "#{prefix}/#{SecureRandom.hex(11)}"
     end
 
     # Returns the id of the batch to which the given transaction belongs

--- a/spec/account_spec.rb
+++ b/spec/account_spec.rb
@@ -39,4 +39,14 @@ describe SEPA::Account do
       expect(SEPA::Account).not_to accept('', 'invalid', for: :bic)
     end
   end
+
+  describe :message_identification_prefix do
+    it 'should accept valid value' do
+      expect(SEPA::Account).to accept(nil, '', 'Test', for: :message_identification_prefix)
+    end
+
+    it 'should not accept invalid value' do
+      expect(SEPA::Account).not_to accept(0000, '@#$%', for: :message_identification_prefix)
+    end
+  end
 end

--- a/spec/account_spec.rb
+++ b/spec/account_spec.rb
@@ -42,11 +42,11 @@ describe SEPA::Account do
 
   describe :message_identification_prefix do
     it 'should accept valid value' do
-      expect(SEPA::Account).to accept(nil, '', 'Test', for: :message_identification_prefix)
+      expect(SEPA::Account).to accept(nil, '', 'S3PA-KING' 'Test', 'SEPA-KING', 'SEPA_KING', for: :message_identification_prefix)
     end
 
     it 'should not accept invalid value' do
-      expect(SEPA::Account).not_to accept(0000, '@#$%', for: :message_identification_prefix)
+      expect(SEPA::Account).not_to accept('@#$%', 'SEPA KING', for: :message_identification_prefix)
     end
   end
 end

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -51,6 +51,15 @@ describe SEPA::Message do
       end
     end
 
+    context 'setting message_identification_prefix on account' do
+      let(:message_identification_prefix) { 'Test' }
+      subject { DummyMessage.new(message_identification_prefix: message_identification_prefix) }
+
+      it 'should return random hex string with passed prefix' do
+        expect(subject.message_identification).to match(/#{message_identification_prefix}\/([a-f0-9]{2}){11}/)
+      end
+    end
+
     describe 'setter' do
       it 'should accept valid ID' do
         [ 'gid://myMoneyApp/Payment/15108', # for example, Rails Global ID could be a candidate


### PR DESCRIPTION
Allow to change the Message Indentification prefix from `SEPA-KING` to any other string with alphanumeric characters (with dash and/or underscore).
